### PR TITLE
[FIX] Scheduling Idle Session Timer Not Working Properly

### DIFF
--- a/helperFunctions/PersistenceHelpers.ts
+++ b/helperFunctions/PersistenceHelpers.ts
@@ -41,7 +41,8 @@ export async function retrievePersistentData(read: IRead, assoc: RocketChatAssoc
 				persistantKey: contentParsed.key as string,
 				sneakPeekEnabled: contentParsed.sneakPeekEnabled as boolean,
 				salesforceAgentName: contentParsed.salesforceAgentName as string,
-				idleSessionScheduleStarted: contentParsed.idleSessionScheduleStarted as boolean,
+				isIdleSessionTimerScheduled: contentParsed.isIdleSessionTimerScheduled as boolean,
+				idleSessionTimerId: contentParsed.idleSessionTimerId as string,
 			};
 		}
 
@@ -52,7 +53,8 @@ export async function retrievePersistentData(read: IRead, assoc: RocketChatAssoc
 			persistantKey: null,
 			sneakPeekEnabled: null,
 			salesforceAgentName: null,
-			idleSessionScheduleStarted: null,
+			isIdleSessionTimerScheduled: null,
+			idleSessionTimerId: null,
 		};
 	} catch (error) {
 		throw new Error(error);


### PR DESCRIPTION
Closes https://github.com/WideChat/Rocket.Chat/issues/968

- Earlier due to race conditions, newly scheduled jobs were also being canceled. Now we are canceling job using jobId, so it only cancels the particular job
- `IOnetimeSchedule` `when` property is not able to parse the time properly if we pass in seconds i.e. `180 seconds`. It was scheduling the job at a random time. So now instead of a string, we are using the `Date` object. 