### PR TITLE
[FIX] Send message to client regardless of timeout handler

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,5 +20,5 @@
         "IRoomUserTyping",
         "IUIKitLivechatInteractionHandler"
     ],
-    "commitHash": "ea13cdc60939ce2627d3fcba80e591c6921d4ad8"
+    "commitHash": "947b904c7e5fe7512fb0d7df174a2ffc0ee02397"
 }

--- a/helperFunctions/TimeoutHelper.ts
+++ b/helperFunctions/TimeoutHelper.ts
@@ -50,20 +50,20 @@ export const handleTimeout = async (app: IApp, message: IMessage, read: IRead, h
 				return;
 			}
 
-			if (sessionTimeoutHandler === 'widget') {
-				const user = await read.getUserReader().getByUsername(salesforceBotUsername);
-				const msgExtender = modify.getExtender().extendMessage(message.id, user);
-				(await msgExtender).addCustomField('idleTimeoutConfig', {
-					idleTimeoutAction: 'start',
-					idleTimeoutWarningTime: warningTime,
-					idleTimeoutTimeoutTime: timeoutTime,
-					idleTimeoutMessage: timeoutWarningMessage,
-				});
-				(await msgExtender).addCustomField('sneakPeekEnabled', sneakPeekEnabled);
-				modify.getExtender().finish(await msgExtender);
-			} else {
+			if (sessionTimeoutHandler === 'app') {
 				await scheduleTimeOut(message, read, modify, persistence, timeoutTime, app, assoc);
 			}
+
+			const user = await read.getUserReader().getByUsername(salesforceBotUsername);
+			const msgExtender = modify.getExtender().extendMessage(message.id, user);
+			(await msgExtender).addCustomField('idleTimeoutConfig', {
+				idleTimeoutAction: 'start',
+				idleTimeoutWarningTime: warningTime,
+				idleTimeoutTimeoutTime: timeoutTime,
+				idleTimeoutMessage: timeoutWarningMessage,
+			});
+			(await msgExtender).addCustomField('sneakPeekEnabled', sneakPeekEnabled);
+			modify.getExtender().finish(await msgExtender);
 		} else {
 			// Guest sent message
 
@@ -71,21 +71,20 @@ export const handleTimeout = async (app: IApp, message: IMessage, read: IRead, h
 				return;
 			}
 
-			if (sessionTimeoutHandler === 'widget') {
-				const user = await read.getUserReader().getByUsername(salesforceBotUsername);
-				const msgExtender = modify.getExtender().extendMessage(message.id, user);
-				(await msgExtender).addCustomField('idleTimeoutConfig', {
-					idleTimeoutAction: 'stop',
-					idleTimeoutWarningTime: warningTime,
-					idleTimeoutTimeoutTime: timeoutTime,
-					idleTimeoutMessage: timeoutWarningMessage,
-				});
-				(await msgExtender).addCustomField('sneakPeekEnabled', sneakPeekEnabled);
-				modify.getExtender().finish(await msgExtender);
-			} else {
+			if (sessionTimeoutHandler === 'app') {
 				await updatePersistentData(read, persistence, assoc, { isIdleSessionTimerScheduled: false, idleSessionTimerId: '' });
 				await modify.getScheduler().cancelJobByDataQuery({rid: message.room.id, taskType: 'sessionTimeout'});
 			}
+			const user = await read.getUserReader().getByUsername(salesforceBotUsername);
+			const msgExtender = modify.getExtender().extendMessage(message.id, user);
+			(await msgExtender).addCustomField('idleTimeoutConfig', {
+				idleTimeoutAction: 'stop',
+				idleTimeoutWarningTime: warningTime,
+				idleTimeoutTimeoutTime: timeoutTime,
+				idleTimeoutMessage: timeoutWarningMessage,
+			});
+			(await msgExtender).addCustomField('sneakPeekEnabled', sneakPeekEnabled);
+			modify.getExtender().finish(await msgExtender);
 		}
 	} else {
 		if (!message.id) {


### PR DESCRIPTION
This fix sends a custom message to the client regardless of the timeout handler setting being `widget` or `app`.